### PR TITLE
Clarify Throw Rock text

### DIFF
--- a/src/rs/src/text.rs
+++ b/src/rs/src/text.rs
@@ -1056,9 +1056,9 @@ impl<'a> SkillThing<'a> {
 				"{x}% chance to poison non-ranged attackers unless poisoned already by shield"
 			)),
 			Skill::throwrock => Cow::from(if self.upped() {
-				"Deal 4 damage to target creature, then shuffle Throw Rock into the creature owner's deck"
+				"Deal 4 damage to target creature, then shuffle Throw Rock into target's owner's deck"
 			} else {
-				"Deal 3 damage to target creature, then shuffle Throw Rock into the creature owner's deck"
+				"Deal 3 damage to target creature, then shuffle Throw Rock into target's owner's deck"
 			}),
 			Skill::tick => Cow::from(if self.upped() {
 				"This creature takes 2 damage. If this damage kills the creature, deal 4 spell damage to all of opponent's creatures"

--- a/src/rs/src/text.rs
+++ b/src/rs/src/text.rs
@@ -1056,9 +1056,9 @@ impl<'a> SkillThing<'a> {
 				"{x}% chance to poison non-ranged attackers unless poisoned already by shield"
 			)),
 			Skill::throwrock => Cow::from(if self.upped() {
-				"Deal 4 damage to target creature, then shuffle Throw Rock into its owner's deck"
+				"Deal 4 damage to target creature, then shuffle Throw Rock into the creature owner's deck"
 			} else {
-				"Deal 3 damage to target creature, then shuffle Throw Rock into its owner's deck"
+				"Deal 3 damage to target creature, then shuffle Throw Rock into the creature owner's deck"
 			}),
 			Skill::tick => Cow::from(if self.upped() {
 				"This creature takes 2 damage. If this damage kills the creature, deal 4 spell damage to all of opponent's creatures"


### PR DESCRIPTION
## Files changed
* `src/rs/src/text.rs`

## What changed
Old Text: "Deal 4 damage to target creature, then shuffle Throw Rock into its owner's deck"
New Text: "Deal 4 damage to target creature, then shuffle Throw Rock into the creature owner's deck"

## Reason
Throw Rock's description has an unclear pronoun because it's not clear if the `owner` in the text refer to the creature's owner or the caster's owner. This change clarifies it is the creature's owner.