### PR TITLE
Update desc for token creatures

### DIFF
--- a/src/rs/src/text.rs
+++ b/src/rs/src/text.rs
@@ -163,7 +163,7 @@ impl<'a> SkillThing<'a> {
 				"Target creature attacks multiple times per turn. Creatures with lower strength attack more times per turn",
 			),
 			Skill::aflatoxin => {
-				Cow::from("Give target 2 poison. When the target dies, it becomes a Malignant Cell")
+				Cow::from("Give target 2 poison. When the target dies, it becomes a 1|1 Malignant Cell that creates new copies")
 			}
 			Skill::aggroskele => {
 				let mut s = String::from("Summon a ");
@@ -332,7 +332,7 @@ impl<'a> SkillThing<'a> {
 				"Burrow. While burrowed, replace this ability with \"2:3 Freeze target permanent.\" Next turn, unburrow, become airborne, & triple this creature's strength until its next attack",
 			),
 			Skill::deja => Cow::from("Remove this ability & summon a copy of this creature"),
-			Skill::deployblobs => Cow::from("Summon 3 Blobs. Gain -2|-2"),
+			Skill::deployblobs => Cow::from("Summon 3 1|1 Blobs that can combine with other creatures. Gain -2|-2"),
 			Skill::despair => Cow::from(
 				"Non-ranged attackers have a 50% chance plus 1% per nocturnal creature you control to gain -1|-1",
 			),
@@ -450,7 +450,7 @@ impl<'a> SkillThing<'a> {
 			)),
 			Skill::firewall => Cow::from("Deals 1 damage to each non-ranged attacking creature"),
 			Skill::fish => Cow::from(
-				"Draw aquatic card from target player's deck. Draw random token if not able to draw an aquatic card. Activate twice if flooded",
+				"Draw aquatic card from target player's deck. Draw random token creature if not able to draw an aquatic card. Activate twice if flooded",
 			),
 			Skill::flooddeath => Cow::from(
 				"Each player's non-aquatic creatures past their first five creature slots die at the end of that player's turn",
@@ -553,7 +553,7 @@ impl<'a> SkillThing<'a> {
 				"When your opponent plays a creature from their hand, summon a Spark"
 			}),
 			Skill::heatstroke if ev == Event::Hit => Cow::from("Opponent summons mirage on hit"),
-			Skill::heatstroke => Cow::from("Opponent summons mirage"),
+			Skill::heatstroke => Cow::from("Opponent summons a 3|6 mirage that heals when blocked"),
 			Skill::hero => Cow::from(
 				"Increase your shield's damage reduction by 1, delaying this card. Increases are correlated; Bo Staff or the shield changing will nullify increased damage reduction. Remove bonus damage reduction by stored when this attacks or is destroyed, resetting stored value",
 			),


### PR DESCRIPTION
## Files changed
* `src/rs/src/text.rs`

## What changed
Updated description for aflatoxin, deployBlobs, fish, and heatstroke

## Reason
There's no easy way to find the stats or abilities of token creatures in the game without actually seeing them being used

## To-do
The generic summon skill should also be updated to at least include the stats of the creature that's being summoned but would be best if it also included their abilities. This applies to the following cards:
* Golden Goose -> Fate Egg
* FFQ -> Firefly (This one in particular matters since changing from light to fire is quite significant)
* Pharaoh -> Scarab
* Jack O Lantern -> Shadow

The following also generate creatures and have stats in the desc but not the abilities
* Heat Mirror -> Spark
* Broken Mirror -> Phantom