### PR TITLE
Sabbath heals creatures for 8 instead of 10

### DIFF
--- a/src/rs/src/skill.rs
+++ b/src/rs/src/skill.rs
@@ -4428,7 +4428,7 @@ impl Skill {
 				}
 				for cr in ctx.get_player(owner).creatures {
 					if cr != 0 {
-						ctx.dmg(cr, -10);
+						ctx.dmg(cr, -8);
 					}
 				}
 				ctx.set(t, Flag::protectdeck, true);


### PR DESCRIPTION
While looking through the code I discovered that Sabbath was healing the user's creatures for 10 instead of 8 as the text suggested. I wasn't sure which value (8 or 10) was the actual intended value and the difference is negligible in almost all scenarios so I went with accepting the text as the source of truth for now